### PR TITLE
1.0.0-beta3: add `create_edge_type_dict` utility to reinforcement learning package

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See [this](https://colab.research.google.com/drive/1XV_Rvq1F2ns6DFG8uNj66q_rcoww
 Version 1.0.0 is currently in beta stage and can be installed with:
 
 ```bash
-pip install job-shop-lib==1.0.0b2
+pip install job-shop-lib==1.0.0b3
 ```
 
 Although this version is not stable and may contain breaking changes in subsequent releases, it is recommended to install it to access the new reinforcement learning environments and familiarize yourself with new changes (see the [latest pull requests](https://github.com/Pabloo22/job_shop_lib/pulls?q=is%3Apr+is%3Aclosed)). There is a [documentation page](https://job-shop-lib.readthedocs.io/en/latest/) for versions 1.0.0a3 and onward.

--- a/job_shop_lib/__init__.py
+++ b/job_shop_lib/__init__.py
@@ -19,7 +19,7 @@ from job_shop_lib._schedule import Schedule
 from job_shop_lib._base_solver import BaseSolver, Solver
 
 
-__version__ = "1.0.0-b.2"
+__version__ = "1.0.0-b.3"
 
 __all__ = [
     "Operation",

--- a/job_shop_lib/graphs/__init__.py
+++ b/job_shop_lib/graphs/__init__.py
@@ -8,9 +8,9 @@ The main classes and functions available in this package are:
     NodeType
     build_disjunctive_graph
     build_solved_disjunctive_graph
-    build_agent_task_graph
-    build_complete_agent_task_graph
-    build_agent_task_graph_with_jobs
+    build_resource_task_graph
+    build_complete_resource_task_graph
+    build_resource_task_graph_with_jobs
 
 """
 

--- a/job_shop_lib/reinforcement_learning/__init__.py
+++ b/job_shop_lib/reinforcement_learning/__init__.py
@@ -12,6 +12,7 @@
     IdleTimeReward
     RenderConfig
     add_padding
+    create_edge_type_dict
 
 """
 
@@ -27,7 +28,10 @@ from job_shop_lib.reinforcement_learning._reward_observers import (
     IdleTimeReward,
 )
 
-from job_shop_lib.reinforcement_learning._utils import add_padding
+from job_shop_lib.reinforcement_learning._utils import (
+    add_padding,
+    create_edge_type_dict,
+)
 
 from job_shop_lib.reinforcement_learning._single_job_shop_graph_env import (
     SingleJobShopGraphEnv,
@@ -47,4 +51,5 @@ __all__ = [
     "ObservationDict",
     "add_padding",
     "MultiJobShopGraphEnv",
+    "create_edge_type_dict",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "job-shop-lib"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 description = "An easy-to-use and modular Python library for the Job Shop Scheduling Problem (JSSP)"
 authors = ["Pabloo22 <pablete.arino@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
- Function `create_edge_type_dict` added. It organizes edges based on node types.
- Fix documentation autosummary of graphs module