### PR TITLE
Change to python 3.10 type hints

### DIFF
--- a/job_shop_lib/_job_shop_instance.py
+++ b/job_shop_lib/_job_shop_instance.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import functools
-from typing import Any, List, Union, Dict
+from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
@@ -51,14 +51,14 @@ class JobShopInstance:
         total_duration
 
     Attributes:
-        jobs (List[List[Operation]]):
+        jobs (list[list[Operation]]):
             A list of lists of operations. Each list of operations represents
             a job, and the operations are ordered by their position in the job.
             The ``job_id``, ``position_in_job``, and ``operation_id``
             attributes of the operations are set when the instance is created.
         name (str):
             A string with the name of the instance.
-        metadata (Dict[str, Any]):
+        metadata (dict[str, Any]):
             A dictionary with additional information about the instance.
 
     Args:
@@ -81,16 +81,16 @@ class JobShopInstance:
 
     def __init__(
         self,
-        jobs: List[List[Operation]],
+        jobs: list[list[Operation]],
         name: str = "JobShopInstance",
         set_operation_attributes: bool = True,
         **metadata: Any,
     ):
-        self.jobs: List[List[Operation]] = jobs
+        self.jobs: list[list[Operation]] = jobs
         if set_operation_attributes:
             self.set_operation_attributes()
         self.name: str = name
-        self.metadata: Dict[str, Any] = metadata
+        self.metadata: dict[str, Any] = metadata
 
     def set_operation_attributes(self):
         """Sets the ``job_id``, ``position_in_job``, and ``operation_id``
@@ -125,10 +125,10 @@ class JobShopInstance:
     @classmethod
     def from_taillard_file(
         cls,
-        file_path: Union[os.PathLike, str, bytes],
+        file_path: os.PathLike | str | bytes,
         encoding: str = "utf-8",
         comment_symbol: str = "#",
-        name: Union[str, None] = None,
+        name: str | None = None,
         **metadata: Any,
     ) -> JobShopInstance:
         """Creates a JobShopInstance from a file following Taillard's format.
@@ -178,7 +178,7 @@ class JobShopInstance:
                 name = name.split(".")[0]
         return cls(jobs=jobs, name=name, **metadata)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Returns a dictionary representation of the instance.
 
         This representation is useful for saving the instance to a JSON file,
@@ -186,7 +186,7 @@ class JobShopInstance:
         like Taillard's.
 
         Returns:
-            Dict[str, Any]: The returned dictionary has the following
+            dict[str, Any]: The returned dictionary has the following
             structure:
 
             .. code-block:: python
@@ -208,10 +208,10 @@ class JobShopInstance:
     @classmethod
     def from_matrices(
         cls,
-        duration_matrix: List[List[int]],
-        machines_matrix: List[List[List[int]]] | List[List[int]],
+        duration_matrix: list[list[int]],
+        machines_matrix: list[list[list[int]]] | list[list[int]],
         name: str = "JobShopInstance",
-        metadata: Dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> JobShopInstance:
         """Creates a :class:`JobShopInstance` from duration and machines
         matrices.
@@ -233,7 +233,7 @@ class JobShopInstance:
         Returns:
             A :class:`JobShopInstance` object.
         """
-        jobs: List[List[Operation]] = [[] for _ in range(len(duration_matrix))]
+        jobs: list[list[Operation]] = [[] for _ in range(len(duration_matrix))]
 
         num_jobs = len(duration_matrix)
         for job_id in range(num_jobs):
@@ -290,7 +290,7 @@ class JobShopInstance:
         )
 
     @functools.cached_property
-    def durations_matrix(self) -> List[List[int]]:
+    def durations_matrix(self) -> list[list[int]]:
         """Returns the duration matrix of the instance.
 
         The duration of the operation with ``job_id`` i and ``position_in_job``
@@ -305,7 +305,7 @@ class JobShopInstance:
         return [[operation.duration for operation in job] for job in self.jobs]
 
     @functools.cached_property
-    def machines_matrix(self) -> Union[List[List[List[int]]], List[List[int]]]:
+    def machines_matrix(self) -> list[list[list[int]]] | list[list[int]]:
         """Returns the machines matrix of the instance.
 
         If the instance is flexible (i.e., if any operation has more than one
@@ -371,25 +371,25 @@ class JobShopInstance:
         machines_matrix = self.machines_matrix
         if self.is_flexible:
             # False positive from mypy, the type of machines_matrix is
-            # List[List[List[int]]] here
+            # list[list[list[int]]] here
             return self._fill_matrix_with_nans_3d(
                 machines_matrix  # type: ignore[arg-type]
             )
 
         # False positive from mypy, the type of machines_matrix is
-        # List[List[int]] here
+        # list[list[int]] here
         return self._fill_matrix_with_nans_2d(
             machines_matrix  # type: ignore[arg-type]
         )
 
     @functools.cached_property
-    def operations_by_machine(self) -> List[List[Operation]]:
+    def operations_by_machine(self) -> list[list[Operation]]:
         """Returns a list of lists of operations.
 
         The i-th list contains the operations that can be processed in the
         machine with id i.
         """
-        operations_by_machine: List[List[Operation]] = [
+        operations_by_machine: list[list[Operation]] = [
             [] for _ in range(self.num_machines)
         ]
         for job in self.jobs:
@@ -409,7 +409,7 @@ class JobShopInstance:
         )
 
     @functools.cached_property
-    def max_duration_per_job(self) -> List[float]:
+    def max_duration_per_job(self) -> list[float]:
         """Returns the maximum duration of each job in the instance.
 
         The maximum duration of the job with id i is stored in the i-th
@@ -420,7 +420,7 @@ class JobShopInstance:
         return [max(op.duration for op in job) for job in self.jobs]
 
     @functools.cached_property
-    def max_duration_per_machine(self) -> List[int]:
+    def max_duration_per_machine(self) -> list[int]:
         """Returns the maximum duration of each machine in the instance.
 
         The maximum duration of the machine with id i is stored in the i-th
@@ -439,7 +439,7 @@ class JobShopInstance:
         return max_duration_per_machine
 
     @functools.cached_property
-    def job_durations(self) -> List[int]:
+    def job_durations(self) -> list[int]:
         """Returns a list with the duration of each job in the instance.
 
         The duration of a job is the sum of the durations of its operations.
@@ -450,7 +450,7 @@ class JobShopInstance:
         return [sum(op.duration for op in job) for job in self.jobs]
 
     @functools.cached_property
-    def machine_loads(self) -> List[int]:
+    def machine_loads(self) -> list[int]:
         """Returns the total machine load of each machine in the instance.
 
         The total machine load of a machine is the sum of the durations of the
@@ -474,7 +474,7 @@ class JobShopInstance:
 
     @staticmethod
     def _fill_matrix_with_nans_2d(
-        matrix: List[List[int]],
+        matrix: list[list[int]],
     ) -> NDArray[np.float32]:
         """Fills a matrix with ``np.nan`` values.
 
@@ -496,7 +496,7 @@ class JobShopInstance:
 
     @staticmethod
     def _fill_matrix_with_nans_3d(
-        matrix: List[List[List[int]]],
+        matrix: list[list[list[int]]],
     ) -> NDArray[np.float32]:
         """Fills a 3D matrix with ``np.nan`` values.
 

--- a/job_shop_lib/_operation.py
+++ b/job_shop_lib/_operation.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Union, List
-
 from job_shop_lib.exceptions import ValidationError
 
 
@@ -61,8 +59,8 @@ class Operation:
         ),
     }
 
-    def __init__(self, machines: Union[int, List[int]], duration: int):
-        self.machines: List[int] = (
+    def __init__(self, machines: int | list[int], duration: int):
+        self.machines: list[int] = (
             [machines] if isinstance(machines, int) else machines
         )
         self.duration: int = duration

--- a/job_shop_lib/_schedule.py
+++ b/job_shop_lib/_schedule.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Union, Dict, Optional
+from typing import Any
 from collections import deque
 
 from job_shop_lib import ScheduledOperation, JobShopInstance
@@ -55,7 +55,7 @@ class Schedule:
     def __init__(
         self,
         instance: JobShopInstance,
-        schedule: Optional[List[List[ScheduledOperation]]] = None,
+        schedule: list[list[ScheduledOperation]] | None = None,
         **metadata: Any,
     ):
         if schedule is None:
@@ -65,19 +65,19 @@ class Schedule:
 
         self.instance: JobShopInstance = instance
         self._schedule = schedule
-        self.metadata: Dict[str, Any] = metadata
+        self.metadata: dict[str, Any] = metadata
 
     def __repr__(self) -> str:
         return str(self.schedule)
 
     @property
-    def schedule(self) -> List[List[ScheduledOperation]]:
+    def schedule(self) -> list[list[ScheduledOperation]]:
         """A list of lists of :class:`ScheduledOperation` objects. Each list
         represents the order of operations on a machine."""
         return self._schedule
 
     @schedule.setter
-    def schedule(self, new_schedule: List[List[ScheduledOperation]]):
+    def schedule(self, new_schedule: list[list[ScheduledOperation]]):
         Schedule.check_schedule(new_schedule)
         self._schedule = new_schedule
 
@@ -103,7 +103,7 @@ class Schedule:
                 - **"metadata"**: A dictionary with additional information
                   about the schedule.
         """
-        job_sequences: List[List[int]] = []
+        job_sequences: list[list[int]] = []
         for machine_schedule in self.schedule:
             job_sequences.append(
                 [operation.job_id for operation in machine_schedule]
@@ -117,9 +117,9 @@ class Schedule:
 
     @staticmethod
     def from_dict(
-        instance: Union[Dict[str, Any], JobShopInstance],
-        job_sequences: List[List[int]],
-        metadata: Optional[Dict[str, Any]] = None,
+        instance: dict[str, Any] | JobShopInstance,
+        job_sequences: list[list[int]],
+        metadata: dict[str, Any] | None = None,
     ) -> Schedule:
         """Creates a schedule from a dictionary representation."""
         if isinstance(instance, dict):
@@ -131,7 +131,7 @@ class Schedule:
     @staticmethod
     def from_job_sequences(
         instance: JobShopInstance,
-        job_sequences: List[List[int]],
+        job_sequences: list[list[int]],
     ) -> Schedule:
         """Creates an active schedule from a list of job sequences.
 
@@ -240,7 +240,7 @@ class Schedule:
         return previous_operation.end_time <= scheduled_operation.start_time
 
     @staticmethod
-    def check_schedule(schedule: List[List[ScheduledOperation]]):
+    def check_schedule(schedule: list[list[ScheduledOperation]]):
         """Checks if a schedule is valid and raises a
         :class:`~exceptions.ValidationError` if it is not.
 

--- a/job_shop_lib/benchmarking/_load_benchmark.py
+++ b/job_shop_lib/benchmarking/_load_benchmark.py
@@ -1,6 +1,6 @@
 """Contains functions to load benchmark instances from a JSON file."""
 
-from typing import Any, Dict
+from typing import Any
 
 import functools
 import json
@@ -10,7 +10,7 @@ from job_shop_lib import JobShopInstance
 
 
 @functools.cache
-def load_all_benchmark_instances() -> Dict[str, JobShopInstance]:
+def load_all_benchmark_instances() -> dict[str, JobShopInstance]:
     """Loads all benchmark instances available.
 
     Returns:
@@ -48,7 +48,7 @@ def load_benchmark_instance(name: str) -> JobShopInstance:
 
 
 @functools.cache
-def load_benchmark_json() -> Dict[str, Dict[str, Any]]:
+def load_benchmark_json() -> dict[str, dict[str, Any]]:
     """Loads the raw JSON file containing the benchmark instances.
 
     Results are cached to avoid reading the file multiple times.

--- a/job_shop_lib/constraint_programming/_ortools_solver.py
+++ b/job_shop_lib/constraint_programming/_ortools_solver.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Tuple
+from typing import Any
 import time
 
 from ortools.sat.python import cp_model
@@ -62,7 +62,7 @@ class ORToolsSolver(BaseSolver):
         self._makespan: cp_model.IntVar | None = None
         self.model = cp_model.CpModel()
         self.solver = cp_model.CpSolver()
-        self._operations_start: Dict[Operation, Tuple[IntVar, IntVar]] = {}
+        self._operations_start: dict[Operation, tuple[IntVar, IntVar]] = {}
 
     def __call__(self, instance: JobShopInstance) -> Schedule:
         """Equivalent to calling the :meth:`~ORToolsSolver.solve` method.
@@ -152,15 +152,15 @@ class ORToolsSolver(BaseSolver):
         self._set_objective(instance)
 
     def _create_schedule(
-        self, instance: JobShopInstance, metadata: Dict[str, Any]
+        self, instance: JobShopInstance, metadata: dict[str, Any]
     ) -> Schedule:
         """Creates a Schedule object from the solution."""
-        operations_start: Dict[Operation, int] = {
+        operations_start: dict[Operation, int] = {
             operation: self.solver.Value(start_var)
             for operation, (start_var, _) in self._operations_start.items()
         }
 
-        unsorted_schedule: List[List[ScheduledOperation]] = [
+        unsorted_schedule: list[list[ScheduledOperation]] = [
             [] for _ in range(instance.num_machines)
         ]
         for operation, start_time in operations_start.items():
@@ -235,7 +235,7 @@ class ORToolsSolver(BaseSolver):
         each machine."""
 
         # Create interval variables for each operation on each machine
-        machines_operations: List[List[Tuple[Tuple[IntVar, IntVar], int]]] = [
+        machines_operations: list[list[tuple[tuple[IntVar, IntVar], int]]] = [
             [] for _ in range(instance.num_machines)
         ]
         for job in instance.jobs:

--- a/job_shop_lib/dispatching/_dispatcher.py
+++ b/job_shop_lib/dispatching/_dispatcher.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import abc
-from typing import Any, TypeVar, List, Optional, Type, Set
+from typing import Any, TypeVar
 from collections.abc import Callable
 from functools import wraps
 
@@ -52,7 +52,7 @@ class DispatcherObserver(abc.ABC):
         class HistoryObserver(DispatcherObserver):
             def __init__(self, dispatcher: Dispatcher):
                 super().__init__(dispatcher)
-                self.history: List[ScheduledOperation] = []
+                self.history: list[ScheduledOperation] = []
 
             def update(self, scheduled_operation: ScheduledOperation):
                 self.history.append(scheduled_operation)
@@ -212,14 +212,14 @@ class Dispatcher:
         self,
         instance: JobShopInstance,
         ready_operations_filter: (
-            Optional[Callable[[Dispatcher, List[Operation]], List[Operation]]]
+            Callable[[Dispatcher, list[Operation]], list[Operation]] | None
         ) = None,
     ) -> None:
 
         self.instance = instance
         self.schedule = Schedule(self.instance)
         self.ready_operations_filter = ready_operations_filter
-        self.subscribers: List[DispatcherObserver] = []
+        self.subscribers: list[DispatcherObserver] = []
 
         self._machine_next_available_time = [0] * self.instance.num_machines
         self._job_next_operation_index = [0] * self.instance.num_jobs
@@ -233,18 +233,18 @@ class Dispatcher:
         return str(self)
 
     @property
-    def machine_next_available_time(self) -> List[int]:
+    def machine_next_available_time(self) -> list[int]:
         """Returns the next available time for each machine."""
         return self._machine_next_available_time
 
     @property
-    def job_next_operation_index(self) -> List[int]:
+    def job_next_operation_index(self) -> list[int]:
         """Returns the index of the next operation to be scheduled for each
         job."""
         return self._job_next_operation_index
 
     @property
-    def job_next_available_time(self) -> List[int]:
+    def job_next_available_time(self) -> list[int]:
         """Returns the next available time for each job."""
         return self._job_next_available_time
 
@@ -267,7 +267,7 @@ class Dispatcher:
             subscriber.reset()
 
     def dispatch(
-        self, operation: Operation, machine_id: Optional[int] = None
+        self, operation: Operation, machine_id: int | None = None
     ) -> None:
         """Schedules the given operation on the given machine.
 
@@ -362,7 +362,7 @@ class Dispatcher:
 
     def create_or_get_observer(
         self,
-        observer: Type[ObserverType],
+        observer: type[ObserverType],
         condition: Callable[[DispatcherObserver], bool] = lambda _: True,
         **kwargs,
     ) -> ObserverType:
@@ -401,7 +401,7 @@ class Dispatcher:
         current_time = self.min_start_time(available_operations)
         return current_time
 
-    def min_start_time(self, operations: List[Operation]) -> int:
+    def min_start_time(self, operations: list[Operation]) -> int:
         """Returns the minimum start time of the available operations."""
         if not operations:
             return self.schedule.makespan()
@@ -413,7 +413,7 @@ class Dispatcher:
         return int(min_start_time)
 
     @_dispatcher_cache
-    def available_operations(self) -> List[Operation]:
+    def available_operations(self) -> list[Operation]:
         """Returns a list of available operations for processing, optionally
         filtering out operations using the filter function.
 
@@ -433,7 +433,7 @@ class Dispatcher:
         return available_operations
 
     @_dispatcher_cache
-    def raw_ready_operations(self) -> List[Operation]:
+    def raw_ready_operations(self) -> list[Operation]:
         """Returns a list of available operations for processing without
         applying the filter function.
 
@@ -449,7 +449,7 @@ class Dispatcher:
         return available_operations
 
     @_dispatcher_cache
-    def unscheduled_operations(self) -> List[Operation]:
+    def unscheduled_operations(self) -> list[Operation]:
         """Returns the list of operations that have not been scheduled."""
         unscheduled_operations = []
         for job_id, next_position in enumerate(self._job_next_operation_index):
@@ -458,7 +458,7 @@ class Dispatcher:
         return unscheduled_operations
 
     @_dispatcher_cache
-    def scheduled_operations(self) -> List[ScheduledOperation]:
+    def scheduled_operations(self) -> list[ScheduledOperation]:
         """Returns the list of operations that have been scheduled."""
         scheduled_operations = []
         for machine_schedule in self.schedule.schedule:
@@ -466,7 +466,7 @@ class Dispatcher:
         return scheduled_operations
 
     @_dispatcher_cache
-    def available_machines(self) -> List[int]:
+    def available_machines(self) -> list[int]:
         """Returns the list of ready machines."""
         available_operations = self.available_operations()
         available_machines = set()
@@ -475,7 +475,7 @@ class Dispatcher:
         return list(available_machines)
 
     @_dispatcher_cache
-    def available_jobs(self) -> List[int]:
+    def available_jobs(self) -> list[int]:
         """Returns the list of ready jobs."""
         available_operations = self.available_operations()
         available_jobs = set(
@@ -530,7 +530,7 @@ class Dispatcher:
         return scheduled_operation.end_time - adjusted_start_time
 
     @_dispatcher_cache
-    def completed_operations(self) -> Set[ScheduledOperation]:
+    def completed_operations(self) -> set[ScheduledOperation]:
         """Returns the set of operations that have been completed.
 
         This method returns the operations that have been scheduled and the
@@ -542,7 +542,7 @@ class Dispatcher:
         return completed_operations
 
     @_dispatcher_cache
-    def uncompleted_operations(self) -> List[Operation]:
+    def uncompleted_operations(self) -> list[Operation]:
         """Returns the list of operations that have not been completed yet.
 
         This method checks for operations that either haven't been scheduled
@@ -561,7 +561,7 @@ class Dispatcher:
         return uncompleted_operations
 
     @_dispatcher_cache
-    def ongoing_operations(self) -> List[ScheduledOperation]:
+    def ongoing_operations(self) -> list[ScheduledOperation]:
         """Returns the list of operations that are currently being processed.
 
         This method returns the operations that have been scheduled and are

--- a/job_shop_lib/dispatching/_dispatcher_observer_config.py
+++ b/job_shop_lib/dispatching/_dispatcher_observer_config.py
@@ -5,7 +5,7 @@ The factory functions create and return the appropriate functions based on the
 specified names or enums.
 """
 
-from typing import TypeVar, Generic, Any, Dict
+from typing import TypeVar, Generic, Any
 
 from dataclasses import dataclass, field
 
@@ -46,7 +46,7 @@ class DispatcherObserverConfig(Generic[T]):
     # We use the type hint T, instead of ObserverType, to allow for string or
     # specific Enum values to be passed as the type argument. For example:
     # FeatureObserverConfig = DispatcherObserverConfig[
-    #     Type[FeatureObserver] | FeatureObserverType | str
+    #     type[FeatureObserver] | FeatureObserverType | str
     # ]
     # This allows for the creation of a FeatureObserver instance
     # from the factory function.
@@ -55,7 +55,7 @@ class DispatcherObserverConfig(Generic[T]):
     enum value, or a string. This is useful for the creation of
     :class:`DispatcherObserver` instances from the factory functions."""
 
-    kwargs: Dict[str, Any] = field(default_factory=dict)
+    kwargs: dict[str, Any] = field(default_factory=dict)
     """Keyword arguments needed to initialize the class. It must not
     contain the ``dispatcher`` argument."""
 

--- a/job_shop_lib/dispatching/_factories.py
+++ b/job_shop_lib/dispatching/_factories.py
@@ -4,7 +4,6 @@ The factory functions create and return the appropriate functions based on the
 specified names or enums.
 """
 
-from typing import Union
 from enum import Enum
 from collections.abc import Iterable
 
@@ -37,7 +36,7 @@ class ReadyOperationsFilterType(str, Enum):
 
 def create_composite_operation_filter(
     ready_operations_filters: Iterable[
-        Union[ReadyOperationsFilter, str, ReadyOperationsFilterType]
+        ReadyOperationsFilter | str | ReadyOperationsFilterType
     ],
 ) -> ReadyOperationsFilter:
     """Creates and returns a :class:`ReadyOperationsFilter` function by
@@ -85,7 +84,7 @@ def create_composite_operation_filter(
 
 
 def ready_operations_filter_factory(
-    filter_name: Union[str, ReadyOperationsFilterType, ReadyOperationsFilter]
+    filter_name: str | ReadyOperationsFilterType | ReadyOperationsFilter,
 ) -> ReadyOperationsFilter:
     """Creates and returns a filter function based on the specified
     filter strategy name.

--- a/job_shop_lib/dispatching/_history_observer.py
+++ b/job_shop_lib/dispatching/_history_observer.py
@@ -1,6 +1,5 @@
 """Home of the `HistoryObserver` class."""
 
-from typing import List
 from job_shop_lib.dispatching import DispatcherObserver, Dispatcher
 from job_shop_lib import ScheduledOperation
 
@@ -10,7 +9,7 @@ class HistoryObserver(DispatcherObserver):
 
     def __init__(self, dispatcher: Dispatcher, *, subscribe: bool = True):
         super().__init__(dispatcher, subscribe=subscribe)
-        self.history: List[ScheduledOperation] = []
+        self.history: list[ScheduledOperation] = []
 
     def update(self, scheduled_operation: ScheduledOperation):
         self.history.append(scheduled_operation)

--- a/job_shop_lib/dispatching/_optimal_operations_observer.py
+++ b/job_shop_lib/dispatching/_optimal_operations_observer.py
@@ -1,6 +1,5 @@
 """Home of the `OptimalOperationsObserver` class."""
 
-from typing import List, Set, Dict
 from job_shop_lib.dispatching import DispatcherObserver, Dispatcher
 from job_shop_lib import Schedule, Operation, ScheduledOperation
 from job_shop_lib.exceptions import ValidationError
@@ -53,9 +52,9 @@ class OptimalOperationsObserver(DispatcherObserver):
             )
 
         self.reference_schedule = reference_schedule
-        self.optimal_available: Set[Operation] = set()
-        self._operation_to_scheduled: Dict[Operation, ScheduledOperation] = {}
-        self._machine_next_operation_index: List[int] = [0] * len(
+        self.optimal_available: set[Operation] = set()
+        self._operation_to_scheduled: dict[Operation, ScheduledOperation] = {}
+        self._machine_next_operation_index: list[int] = [0] * len(
             reference_schedule.schedule
         )
 

--- a/job_shop_lib/dispatching/_ready_operation_filters.py
+++ b/job_shop_lib/dispatching/_ready_operation_filters.py
@@ -4,7 +4,6 @@ This functions are used by the `Dispatcher` class to reduce the
 amount of available operations to choose from.
 """
 
-from typing import List, Set
 from collections.abc import Callable
 
 from job_shop_lib import Operation
@@ -12,13 +11,13 @@ from job_shop_lib.dispatching import Dispatcher
 
 
 ReadyOperationsFilter = Callable[
-    [Dispatcher, List[Operation]], List[Operation]
+    [Dispatcher, list[Operation]], list[Operation]
 ]
 
 
 def filter_non_idle_machines(
-    dispatcher: Dispatcher, operations: List[Operation]
-) -> List[Operation]:
+    dispatcher: Dispatcher, operations: list[Operation]
+) -> list[Operation]:
     """Filters out all the operations associated with non-idle machines.
 
     A machine is considered idle if there are no ongoing operations
@@ -41,7 +40,7 @@ def filter_non_idle_machines(
 
     # Filter operations to keep those that are associated with at least one
     # idle machine
-    filtered_operations: List[Operation] = []
+    filtered_operations: list[Operation] = []
     for operation in operations:
         if all(
             machine_id in non_idle_machines
@@ -55,7 +54,7 @@ def filter_non_idle_machines(
 
 def _get_non_idle_machines(
     dispatcher: Dispatcher, current_time: int
-) -> Set[int]:
+) -> set[int]:
     """Returns the set of machine ids that are currently busy (i.e., have at
     least one uncompleted operation)."""
 
@@ -71,8 +70,8 @@ def _get_non_idle_machines(
 
 
 def filter_non_immediate_operations(
-    dispatcher: Dispatcher, operations: List[Operation]
-) -> List[Operation]:
+    dispatcher: Dispatcher, operations: list[Operation]
+) -> list[Operation]:
     """Filters out all the operations that can't start immediately.
 
     An operation can start immediately if its earliest start time is the
@@ -87,7 +86,7 @@ def filter_non_immediate_operations(
     """
 
     min_start_time = dispatcher.min_start_time(operations)
-    immediate_operations: List[Operation] = []
+    immediate_operations: list[Operation] = []
     for operation in operations:
         start_time = dispatcher.earliest_start_time(operation)
         if start_time == min_start_time:
@@ -97,8 +96,8 @@ def filter_non_immediate_operations(
 
 
 def filter_dominated_operations(
-    dispatcher: Dispatcher, operations: List[Operation]
-) -> List[Operation]:
+    dispatcher: Dispatcher, operations: list[Operation]
+) -> list[Operation]:
     """Filters out all the operations that are dominated.
     An operation is dominated if there is another operation that ends before
     it starts on the same machine.
@@ -106,7 +105,7 @@ def filter_dominated_operations(
 
     min_machine_end_times = _get_min_machine_end_times(dispatcher, operations)
 
-    non_dominated_operations: List[Operation] = []
+    non_dominated_operations: list[Operation] = []
     for operation in operations:
         # One benchmark instance has an operation with duration 0
         if operation.duration == 0:
@@ -122,13 +121,13 @@ def filter_dominated_operations(
 
 
 def filter_non_immediate_machines(
-    dispatcher: Dispatcher, operations: List[Operation]
-) -> List[Operation]:
+    dispatcher: Dispatcher, operations: list[Operation]
+) -> list[Operation]:
     """Filters out all the operations associated with machines which earliest
     operation is not the current time."""
 
     is_immediate_machine = _get_immediate_machines(dispatcher, operations)
-    non_dominated_operations: List[Operation] = []
+    non_dominated_operations: list[Operation] = []
     for operation in operations:
         if any(
             is_immediate_machine[machine_id]
@@ -140,8 +139,8 @@ def filter_non_immediate_machines(
 
 
 def _get_min_machine_end_times(
-    dispatcher: Dispatcher, available_operations: List[Operation]
-) -> List[float]:
+    dispatcher: Dispatcher, available_operations: list[Operation]
+) -> list[float]:
     end_times_per_machine = [float("inf")] * dispatcher.instance.num_machines
     for op in available_operations:
         for machine_id in op.machines:
@@ -153,8 +152,8 @@ def _get_min_machine_end_times(
 
 
 def _get_immediate_machines(
-    dispatcher: Dispatcher, available_operations: List[Operation]
-) -> List[bool]:
+    dispatcher: Dispatcher, available_operations: list[Operation]
+) -> list[bool]:
     """Returns the machine ids of the machines that have at least one
     operation with the lowest start time (i.e. the start time)."""
     working_machines = [False] * dispatcher.instance.num_machines

--- a/job_shop_lib/dispatching/_unscheduled_operations_observer.py
+++ b/job_shop_lib/dispatching/_unscheduled_operations_observer.py
@@ -3,7 +3,6 @@
 import collections
 from collections.abc import Iterable
 import itertools
-from typing import Deque, List
 
 from job_shop_lib import Operation, ScheduledOperation
 from job_shop_lib.dispatching import DispatcherObserver, Dispatcher
@@ -19,7 +18,9 @@ class UnscheduledOperationsObserver(DispatcherObserver):
 
     def __init__(self, dispatcher: Dispatcher, *, subscribe: bool = True):
         super().__init__(dispatcher, subscribe=subscribe)
-        self.unscheduled_operations_per_job: List[Deque[Operation]] = []
+        self.unscheduled_operations_per_job: list[
+            collections.deque[Operation]
+        ] = []
         self.reset()
         # In case the dispatcher has already scheduled some operations,
         # we need to remove them.

--- a/job_shop_lib/dispatching/feature_observers/_composite_feature_observer.py
+++ b/job_shop_lib/dispatching/feature_observers/_composite_feature_observer.py
@@ -2,7 +2,7 @@
 
 from collections import defaultdict
 from collections.abc import Sequence
-from typing import List, Dict, Union, Optional, Type
+
 # The Self type can be imported directly from Python’s typing module in
 # version 3.11 and beyond. We use the typing_extensions module to support
 # python >=3.10
@@ -77,8 +77,8 @@ class CompositeFeatureObserver(FeatureObserver):
         dispatcher: Dispatcher,
         *,
         subscribe: bool = True,
-        feature_types: Optional[Union[List[FeatureType], FeatureType]] = None,
-        feature_observers: Optional[List[FeatureObserver]] = None,
+        feature_types: list[FeatureType] | FeatureType | None = None,
+        feature_observers: list[FeatureObserver] | None = None,
     ):
         if feature_observers is None:
             feature_observers = [
@@ -97,7 +97,7 @@ class CompositeFeatureObserver(FeatureObserver):
                     f"Composite feature types: {feature_types}"
                 )
         self.feature_observers = feature_observers
-        self.column_names: Dict[FeatureType, List[str]] = defaultdict(list)
+        self.column_names: dict[FeatureType, list[str]] = defaultdict(list)
         super().__init__(dispatcher, subscribe=subscribe)
         self._set_column_names()
 
@@ -106,12 +106,10 @@ class CompositeFeatureObserver(FeatureObserver):
         cls,
         dispatcher: Dispatcher,
         feature_observer_configs: Sequence[
-            Union[
-                str,
-                FeatureObserverType,
-                Type[FeatureObserver],
-                FeatureObserverConfig,
-            ],
+            str
+            | FeatureObserverType
+            | type[FeatureObserver]
+            | FeatureObserverConfig
         ],
         subscribe: bool = True,
     ) -> Self:
@@ -136,7 +134,7 @@ class CompositeFeatureObserver(FeatureObserver):
         return composite_observer
 
     @property
-    def features_as_dataframe(self) -> Dict[FeatureType, pd.DataFrame]:
+    def features_as_dataframe(self) -> dict[FeatureType, pd.DataFrame]:
         """Returns the features as a dictionary of `pd.DataFrame` instances."""
         return {
             feature_type: pd.DataFrame(
@@ -146,7 +144,7 @@ class CompositeFeatureObserver(FeatureObserver):
         }
 
     def initialize_features(self):
-        features: Dict[FeatureType, List[NDArray[np.float32]]] = defaultdict(
+        features: dict[FeatureType, list[NDArray[np.float32]]] = defaultdict(
             list
         )
         for observer in self.feature_observers:

--- a/job_shop_lib/dispatching/feature_observers/_earliest_start_time_observer.py
+++ b/job_shop_lib/dispatching/feature_observers/_earliest_start_time_observer.py
@@ -1,7 +1,5 @@
 """Home of the `EarliestStartTimeObserver` class."""
 
-from typing import List, Optional, Union
-
 import numpy as np
 from numpy.typing import NDArray
 
@@ -77,7 +75,7 @@ class EarliestStartTimeObserver(FeatureObserver):
         dispatcher: Dispatcher,
         *,
         subscribe: bool = True,
-        feature_types: Optional[Union[List[FeatureType], FeatureType]] = None,
+        feature_types: list[FeatureType] | FeatureType | None = None,
     ):
 
         # Earliest start times initialization

--- a/job_shop_lib/dispatching/feature_observers/_factory.py
+++ b/job_shop_lib/dispatching/feature_observers/_factory.py
@@ -1,7 +1,6 @@
 """Contains factory functions for creating :class:`FeatureObserver`s."""
 
 from enum import Enum
-from typing import Union, Type
 
 from job_shop_lib.dispatching import DispatcherObserverConfig
 from job_shop_lib.dispatching.feature_observers import (
@@ -37,25 +36,25 @@ class FeatureObserverType(str, Enum):
 
 
 # FeatureObserverConfig = DispatcherObserverConfig[
-#     Type[FeatureObserver] | FeatureObserverType | str
+#     type[FeatureObserver] | FeatureObserverType | str
 # ]
 # FeatureObserverConfig = DispatcherObserverConfig[
-#     Union[Type[FeatureObserver], FeatureObserverType, str]
+#     Union[type[FeatureObserver], FeatureObserverType, str]
 # ]
 FeatureObserverConfig = (
-    DispatcherObserverConfig[Type[FeatureObserver]]
+    DispatcherObserverConfig[type[FeatureObserver]]
     | DispatcherObserverConfig[FeatureObserverType]
     | DispatcherObserverConfig[str]
 )
 
 
 def feature_observer_factory(
-    feature_observer_type: Union[
-        str,
-        FeatureObserverType,
-        Type[FeatureObserver],
-        FeatureObserverConfig
-    ],
+    feature_observer_type: (
+        str
+        | FeatureObserverType
+        | type[FeatureObserver]
+        | FeatureObserverConfig
+    ),
     **kwargs,
 ) -> FeatureObserver:
     """Creates and returns a :class:`FeatureObserver` based on the specified
@@ -77,12 +76,12 @@ def feature_observer_factory(
             **feature_observer_type.kwargs,
             **kwargs,
         )
-    # if the instance is of type Type[FeatureObserver] we can just
+    # if the instance is of type type[FeatureObserver] we can just
     # call the object constructor with the keyword arguments
     if isinstance(feature_observer_type, type):
         return feature_observer_type(**kwargs)
 
-    mapping: dict[FeatureObserverType, Type[FeatureObserver]] = {
+    mapping: dict[FeatureObserverType, type[FeatureObserver]] = {
         FeatureObserverType.IS_READY: IsReadyObserver,
         FeatureObserverType.EARLIEST_START_TIME: EarliestStartTimeObserver,
         FeatureObserverType.DURATION: DurationObserver,

--- a/job_shop_lib/dispatching/feature_observers/_feature_observer.py
+++ b/job_shop_lib/dispatching/feature_observers/_feature_observer.py
@@ -1,7 +1,6 @@
 """Home of the `FeatureObserver` class and `FeatureType` enum."""
 
 import enum
-from typing import Optional, Union, Dict, List, Tuple
 
 import numpy as np
 
@@ -65,7 +64,7 @@ class FeatureObserver(DispatcherObserver):
     """
 
     _is_singleton = False
-    _feature_sizes: Union[Dict[FeatureType, int], int] = 1
+    _feature_sizes: dict[FeatureType, int] | int = 1
     _supported_feature_types = list(FeatureType)
 
     __slots__ = {
@@ -85,7 +84,7 @@ class FeatureObserver(DispatcherObserver):
         dispatcher: Dispatcher,
         *,
         subscribe: bool = True,
-        feature_types: Optional[Union[List[FeatureType], FeatureType]] = None,
+        feature_types: list[FeatureType] | FeatureType | None = None,
     ):
         feature_types = self._get_feature_types_list(feature_types)
         if isinstance(self._feature_sizes, int):
@@ -117,7 +116,7 @@ class FeatureObserver(DispatcherObserver):
         self.initialize_features()
 
     @property
-    def feature_sizes(self) -> Dict[FeatureType, int]:
+    def feature_sizes(self) -> dict[FeatureType, int]:
         """Returns the size of the features.
 
         The size of the features is the number of values being observed for
@@ -135,12 +134,12 @@ class FeatureObserver(DispatcherObserver):
         return self._feature_sizes
 
     @property
-    def supported_feature_types(self) -> List[FeatureType]:
+    def supported_feature_types(self) -> list[FeatureType]:
         """Returns the supported feature types."""
         return self._supported_feature_types
 
     @property
-    def feature_dimensions(self) -> Dict[FeatureType, Tuple[int, int]]:
+    def feature_dimensions(self) -> dict[FeatureType, tuple[int, int]]:
         """A dictionary containing the shape of each :class:`FeatureType`."""
         feature_dimensions = {}
         for feature_type, array in self.features.items():
@@ -171,7 +170,7 @@ class FeatureObserver(DispatcherObserver):
         self.initialize_features()
 
     def set_features_to_zero(
-        self, exclude: Optional[Union[FeatureType, List[FeatureType]]] = None
+        self, exclude: FeatureType | list[FeatureType] | None = None
     ):
         """Sets all features to zero except for the ones specified in
         ``exclude``.
@@ -197,8 +196,8 @@ class FeatureObserver(DispatcherObserver):
 
     def _get_feature_types_list(
         self,
-        feature_types: Optional[Union[List[FeatureType], FeatureType]],
-    ) -> List[FeatureType]:
+        feature_types: list[FeatureType] | FeatureType | None,
+    ) -> list[FeatureType]:
         """Returns a list of feature types.
 
         Args:

--- a/job_shop_lib/dispatching/feature_observers/_is_completed_observer.py
+++ b/job_shop_lib/dispatching/feature_observers/_is_completed_observer.py
@@ -1,6 +1,5 @@
 """Home of the `IsCompletedObserver` class."""
 
-from typing import Optional, Union, List
 import numpy as np
 
 from job_shop_lib import ScheduledOperation
@@ -40,7 +39,7 @@ class IsCompletedObserver(FeatureObserver):
         self,
         dispatcher: Dispatcher,
         *,
-        feature_types: Optional[Union[List[FeatureType], FeatureType]] = None,
+        feature_types: list[FeatureType] | FeatureType | None = None,
         subscribe: bool = True,
     ):
         feature_types = self._get_feature_types_list(feature_types)
@@ -86,8 +85,7 @@ class IsCompletedObserver(FeatureObserver):
             for op in self.dispatcher.completed_operations():
                 num_completed_ops_per_job[op.operation.job_id] += 1
             self.features[FeatureType.JOBS][:, 0] = (
-                num_completed_ops_per_job
-                == self._num_of_operations_per_job
+                num_completed_ops_per_job == self._num_of_operations_per_job
             ).astype(np.float32)
 
     def reset(self):

--- a/job_shop_lib/dispatching/feature_observers/_is_ready_observer.py
+++ b/job_shop_lib/dispatching/feature_observers/_is_ready_observer.py
@@ -1,7 +1,5 @@
 """Home of the `IsReadyObserver` class."""
 
-from typing import List
-
 from job_shop_lib.dispatching.feature_observers import (
     FeatureObserver,
     FeatureType,
@@ -18,7 +16,7 @@ class IsReadyObserver(FeatureObserver):
             feature_ids = self._get_ready_feature_ids(feature_type)
             feature[feature_ids, 0] = 1.0
 
-    def _get_ready_feature_ids(self, feature_type: FeatureType) -> List[int]:
+    def _get_ready_feature_ids(self, feature_type: FeatureType) -> list[int]:
         if feature_type == FeatureType.OPERATIONS:
             return self._get_ready_operations()
         if feature_type == FeatureType.MACHINES:
@@ -30,6 +28,6 @@ class IsReadyObserver(FeatureObserver):
     def reset(self):
         self.initialize_features()
 
-    def _get_ready_operations(self) -> List[int]:
+    def _get_ready_operations(self) -> list[int]:
         available_operations = self.dispatcher.available_operations()
         return [operation.operation_id for operation in available_operations]

--- a/job_shop_lib/dispatching/rules/_dispatching_rule_factory.py
+++ b/job_shop_lib/dispatching/rules/_dispatching_rule_factory.py
@@ -5,8 +5,6 @@ The factory functions create and return the appropriate functions based on the
 specified names or enums.
 """
 
-from typing import Dict, Union
-
 from enum import Enum
 from collections.abc import Callable
 
@@ -33,7 +31,7 @@ class DispatchingRuleType(str, Enum):
 
 
 def dispatching_rule_factory(
-    dispatching_rule: Union[str, DispatchingRuleType],
+    dispatching_rule: str | DispatchingRuleType,
 ) -> Callable[[Dispatcher], Operation]:
     """Creates and returns a dispatching rule function based on the specified
     dispatching rule name.
@@ -57,7 +55,7 @@ def dispatching_rule_factory(
             If the dispatching_rule argument is not recognized or it is
             not supported.
     """
-    dispatching_rules: Dict[
+    dispatching_rules: dict[
         DispatchingRuleType,
         Callable[[Dispatcher], Operation],
     ] = {

--- a/job_shop_lib/dispatching/rules/_dispatching_rule_solver.py
+++ b/job_shop_lib/dispatching/rules/_dispatching_rule_solver.py
@@ -1,6 +1,5 @@
 """Home of the `DispatchingRuleSolver` class."""
 
-from typing import Optional, Union
 from collections.abc import Callable, Iterable
 
 from job_shop_lib import JobShopInstance, Schedule, Operation, BaseSolver
@@ -66,24 +65,19 @@ class DispatchingRuleSolver(BaseSolver):
 
     def __init__(
         self,
-        dispatching_rule: Union[
-            str, Callable[[Dispatcher], Operation]
-        ] = DispatchingRuleType.MOST_WORK_REMAINING,
-        machine_chooser: Union[
-            str, Callable[[Dispatcher, Operation], int]
-        ] = MachineChooserType.FIRST,
-        ready_operations_filter: Optional[
-            Union[
-                Iterable[
-                    Union[
-                        ReadyOperationsFilter, str, ReadyOperationsFilterType
-                    ]
-                ],
-                str,
-                ReadyOperationsFilterType,
-                ReadyOperationsFilter,
-            ]
-        ] = (
+        dispatching_rule: (
+            str | Callable[[Dispatcher], Operation]
+        ) = DispatchingRuleType.MOST_WORK_REMAINING,
+        machine_chooser: (
+            str | Callable[[Dispatcher, Operation], int]
+        ) = MachineChooserType.FIRST,
+        ready_operations_filter: (
+            Iterable[ReadyOperationsFilter | str | ReadyOperationsFilterType]
+            | str
+            | ReadyOperationsFilterType
+            | ReadyOperationsFilter
+            | None
+        ) = (
             ReadyOperationsFilterType.DOMINATED_OPERATIONS,
             ReadyOperationsFilterType.NON_IMMEDIATE_OPERATIONS,
         ),
@@ -108,7 +102,7 @@ class DispatchingRuleSolver(BaseSolver):
     def solve(
         self,
         instance: JobShopInstance,
-        dispatcher: Optional[Dispatcher] = None,
+        dispatcher: Dispatcher | None = None,
     ) -> Schedule:
         """Solves the instance using the dispatching rule and machine chooser
         algorithms.
@@ -159,6 +153,7 @@ class DispatchingRuleSolver(BaseSolver):
 if __name__ == "__main__":
     import time
     import cProfile
+
     # import pstats
     # from io import StringIO
     from job_shop_lib.benchmarking import (

--- a/job_shop_lib/dispatching/rules/_dispatching_rules_functions.py
+++ b/job_shop_lib/dispatching/rules/_dispatching_rules_functions.py
@@ -6,7 +6,6 @@ which operations are selected for execution based on certain criteria such as
 shortest processing time, first come first served, etc.
 """
 
-from typing import List, Optional
 from collections.abc import Callable, Sequence
 import random
 
@@ -65,7 +64,7 @@ def random_operation_rule(dispatcher: Dispatcher) -> Operation:
 
 
 def score_based_rule(
-    score_function: Callable[[Dispatcher], Sequence[float]]
+    score_function: Callable[[Dispatcher], Sequence[float]],
 ) -> Callable[[Dispatcher], Operation]:
     """Creates a dispatching rule based on a scoring function.
 
@@ -89,7 +88,7 @@ def score_based_rule(
 
 
 def score_based_rule_with_tie_breaker(
-    score_functions: List[Callable[[Dispatcher], Sequence[int]]],
+    score_functions: list[Callable[[Dispatcher], Sequence[int]]],
 ) -> Callable[[Dispatcher], Operation]:
     """Creates a dispatching rule based on multiple scoring functions.
 
@@ -123,7 +122,7 @@ def score_based_rule_with_tie_breaker(
 # -----------------
 
 
-def shortest_processing_time_score(dispatcher: Dispatcher) -> List[int]:
+def shortest_processing_time_score(dispatcher: Dispatcher) -> list[int]:
     """Scores each job based on the duration of the next operation."""
     num_jobs = dispatcher.instance.num_jobs
     scores = [0] * num_jobs
@@ -132,7 +131,7 @@ def shortest_processing_time_score(dispatcher: Dispatcher) -> List[int]:
     return scores
 
 
-def first_come_first_served_score(dispatcher: Dispatcher) -> List[int]:
+def first_come_first_served_score(dispatcher: Dispatcher) -> list[int]:
     """Scores each job based on the position of the next operation."""
     num_jobs = dispatcher.instance.num_jobs
     scores = [0] * num_jobs
@@ -154,9 +153,9 @@ class MostWorkRemainingScorer:  # pylint: disable=too-few-public-methods
     """
 
     def __init__(self) -> None:
-        self._duration_observer: Optional[DurationObserver] = None
-        self._is_ready_observer: Optional[IsReadyObserver] = None
-        self._current_dispatcher: Optional[Dispatcher] = None
+        self._duration_observer: DurationObserver | None = None
+        self._is_ready_observer: IsReadyObserver | None = None
+        self._current_dispatcher: Dispatcher | None = None
 
     def __call__(self, dispatcher: Dispatcher) -> Sequence[int]:
         """Scores each job based on the remaining work in the job."""
@@ -198,7 +197,7 @@ observer_based_most_work_remaining_rule = score_based_rule(
 )
 
 
-def most_operations_remaining_score(dispatcher: Dispatcher) -> List[int]:
+def most_operations_remaining_score(dispatcher: Dispatcher) -> list[int]:
     """Scores each job based on the remaining operations in the job."""
     num_jobs = dispatcher.instance.num_jobs
     scores = [0] * num_jobs
@@ -207,7 +206,7 @@ def most_operations_remaining_score(dispatcher: Dispatcher) -> List[int]:
     return scores
 
 
-def random_score(dispatcher: Dispatcher) -> List[int]:
+def random_score(dispatcher: Dispatcher) -> list[int]:
     """Scores each job randomly."""
     return [
         random.randint(0, 100) for _ in range(dispatcher.instance.num_jobs)

--- a/job_shop_lib/dispatching/rules/_machine_chooser_factory.py
+++ b/job_shop_lib/dispatching/rules/_machine_chooser_factory.py
@@ -5,7 +5,6 @@ The factory functions create and return the appropriate functions based on the
 specified names or enums.
 """
 
-from typing import Union, Dict
 from enum import Enum
 from collections.abc import Callable
 import random
@@ -26,7 +25,7 @@ MachineChooser = Callable[[Dispatcher, Operation], int]
 
 
 def machine_chooser_factory(
-    machine_chooser: Union[str, MachineChooser],
+    machine_chooser: str | MachineChooser,
 ) -> MachineChooser:
     """Creates and returns a machine chooser function based on the specified
     machine chooser strategy name.
@@ -51,7 +50,7 @@ def machine_chooser_factory(
             If the ``machine_chooser`` argument is not recognized or
             is not supported.
     """
-    machine_choosers: Dict[str, Callable[[Dispatcher, Operation], int]] = {
+    machine_choosers: dict[str, Callable[[Dispatcher, Operation], int]] = {
         MachineChooserType.FIRST: lambda _, operation: operation.machines[0],
         MachineChooserType.RANDOM: lambda _, operation: random.choice(
             operation.machines

--- a/job_shop_lib/dispatching/rules/_utils.py
+++ b/job_shop_lib/dispatching/rules/_utils.py
@@ -1,6 +1,5 @@
 """Utility functions."""
 
-from typing import Union, List
 import time
 from collections.abc import Callable
 import pandas as pd
@@ -11,12 +10,12 @@ from job_shop_lib.dispatching import Dispatcher
 
 
 def benchmark_dispatching_rules(
-    dispatching_rules: Union[
-        List[Union[str, Callable[[Dispatcher], Operation]]],
-        List[str],
-        List[Callable[[Dispatcher], Operation]]
-    ],
-    instances: List[JobShopInstance],
+    dispatching_rules: (
+        list[str | Callable[[Dispatcher], Operation]]
+        | list[str]
+        | list[Callable[[Dispatcher], Operation]]
+    ),
+    instances: list[JobShopInstance],
 ) -> pd.DataFrame:
     """Benchmark multiple dispatching rules on multiple JobShopInstances.
 
@@ -112,7 +111,7 @@ if __name__ == "__main__":
     instances_ = [load_benchmark_instance(f"ta{i:02d}") for i in range(1, 3)]
 
     # Define rules
-    rules_: List[str | Callable[[Dispatcher], Operation]] = [
+    rules_: list[str | Callable[[Dispatcher], Operation]] = [
         "most_work_remaining",
         "shortest_processing_time",
         most_work_remaining_rule,

--- a/job_shop_lib/generation/_general_instance_generator.py
+++ b/job_shop_lib/generation/_general_instance_generator.py
@@ -1,6 +1,5 @@
 """Home of the `BasicGenerator` class."""
 
-from typing import Optional, Tuple, Union
 import random
 
 from job_shop_lib import JobShopInstance
@@ -81,15 +80,15 @@ class GeneralInstanceGenerator(InstanceGenerator):
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        num_jobs: Union[int, Tuple[int, int]] = (10, 20),
-        num_machines: Union[int, Tuple[int, int]] = (5, 10),
-        duration_range: Tuple[int, int] = (1, 99),
+        num_jobs: int | tuple[int, int] = (10, 20),
+        num_machines: int | tuple[int, int] = (5, 10),
+        duration_range: tuple[int, int] = (1, 99),
         allow_less_jobs_than_machines: bool = True,
         allow_recirculation: bool = False,
-        machines_per_operation: Union[int, Tuple[int, int]] = 1,
+        machines_per_operation: int | tuple[int, int] = 1,
         name_suffix: str = "classic_generated_instance",
-        seed: Optional[int] = None,
-        iteration_limit: Optional[int] = None,
+        seed: int | None = None,
+        iteration_limit: int | None = None,
     ):
         super().__init__(
             num_jobs=num_jobs,
@@ -127,8 +126,8 @@ class GeneralInstanceGenerator(InstanceGenerator):
 
     def generate(
         self,
-        num_jobs: Optional[int] = None,
-        num_machines: Optional[int] = None,
+        num_jobs: int | None = None,
+        num_machines: int | None = None,
     ) -> JobShopInstance:
         if num_jobs is None:
             num_jobs = random.randint(*self.num_jobs_range)

--- a/job_shop_lib/generation/_instance_generator.py
+++ b/job_shop_lib/generation/_instance_generator.py
@@ -3,7 +3,7 @@
 import abc
 
 import random
-from typing import Iterator, Optional, Tuple, Union
+from typing import Iterator
 
 from job_shop_lib import JobShopInstance
 from job_shop_lib.exceptions import UninitializedAttributeError
@@ -52,12 +52,12 @@ class InstanceGenerator(abc.ABC):
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        num_jobs: Union[int, Tuple[int, int]] = (10, 20),
-        num_machines: Union[int, Tuple[int, int]] = (5, 10),
-        duration_range: Tuple[int, int] = (1, 99),
+        num_jobs: int | tuple[int, int] = (10, 20),
+        num_machines: int | tuple[int, int] = (5, 10),
+        duration_range: tuple[int, int] = (1, 99),
         name_suffix: str = "generated_instance",
-        seed: Optional[int] = None,
-        iteration_limit: Optional[int] = None,
+        seed: int | None = None,
+        iteration_limit: int | None = None,
     ):
         if isinstance(num_jobs, int):
             num_jobs = (num_jobs, num_jobs)
@@ -78,8 +78,8 @@ class InstanceGenerator(abc.ABC):
     @abc.abstractmethod
     def generate(
         self,
-        num_jobs: Optional[int] = None,
-        num_machines: Optional[int] = None,
+        num_jobs: int | None = None,
+        num_machines: int | None = None,
     ) -> JobShopInstance:
         """Generates a single job shop instance
 

--- a/job_shop_lib/generation/_transformations.py
+++ b/job_shop_lib/generation/_transformations.py
@@ -3,7 +3,6 @@
 import abc
 import copy
 import random
-from typing import Optional
 
 from job_shop_lib import JobShopInstance, Operation
 
@@ -39,7 +38,7 @@ class RemoveMachines(Transformation):
     """Removes operations associated with randomly selected machines until
     there are exactly num_machines machines left."""
 
-    def __init__(self, num_machines: int, suffix: Optional[str] = None):
+    def __init__(self, num_machines: int, suffix: str | None = None):
         if suffix is None:
             suffix = f"_machines={num_machines}"
         super().__init__(suffix=suffix)
@@ -84,7 +83,7 @@ class AddDurationNoise(Transformation):
         min_duration: int = 1,
         max_duration: int = 100,
         noise_level: int = 10,
-        suffix: Optional[str] = None,
+        suffix: str | None = None,
     ):
         if suffix is None:
             suffix = f"_noise={noise_level}"
@@ -128,8 +127,8 @@ class RemoveJobs(Transformation):
         self,
         min_jobs: int,
         max_jobs: int,
-        target_jobs: Optional[int] = None,
-        suffix: Optional[str] = None,
+        target_jobs: int | None = None,
+        suffix: str | None = None,
     ):
         if suffix is None:
             suffix = f"_jobs={min_jobs}-{max_jobs}"

--- a/job_shop_lib/generation/_utils.py
+++ b/job_shop_lib/generation/_utils.py
@@ -1,4 +1,3 @@
-from typing import Tuple
 import numpy as np
 from numpy.typing import NDArray
 
@@ -6,7 +5,7 @@ from job_shop_lib.exceptions import ValidationError
 
 
 def generate_duration_matrix(
-    num_jobs: int, num_machines: int, duration_range: Tuple[int, int]
+    num_jobs: int, num_machines: int, duration_range: tuple[int, int]
 ) -> NDArray[np.int32]:
     """Generates a duration matrix.
 

--- a/job_shop_lib/graphs/_job_shop_graph.py
+++ b/job_shop_lib/graphs/_job_shop_graph.py
@@ -1,6 +1,5 @@
 """Home of the `JobShopGraph` class."""
 
-from typing import List, Union, Dict
 import collections
 import networkx as nx
 
@@ -63,23 +62,23 @@ class JobShopGraph:
         self.graph = nx.DiGraph()
         self.instance = instance
 
-        self._nodes: List[Node] = []
-        self._nodes_by_type: Dict[NodeType, List[Node]] = (
+        self._nodes: list[Node] = []
+        self._nodes_by_type: dict[NodeType, list[Node]] = (
             collections.defaultdict(list)
         )
-        self._nodes_by_machine: List[List[Node]] = [
+        self._nodes_by_machine: list[list[Node]] = [
             [] for _ in range(instance.num_machines)
         ]
-        self._nodes_by_job: List[List[Node]] = [
+        self._nodes_by_job: list[list[Node]] = [
             [] for _ in range(instance.num_jobs)
         ]
         self._next_node_id = 0
-        self.removed_nodes: List[bool] = []
+        self.removed_nodes: list[bool] = []
         if add_operation_nodes:
             self.add_operation_nodes()
 
     @property
-    def nodes(self) -> List[Node]:
+    def nodes(self) -> list[Node]:
         """List of all nodes added to the graph.
 
         It may contain nodes that have been removed from the graph.
@@ -87,7 +86,7 @@ class JobShopGraph:
         return self._nodes
 
     @property
-    def nodes_by_type(self) -> Dict[NodeType, List[Node]]:
+    def nodes_by_type(self) -> dict[NodeType, list[Node]]:
         """Dictionary mapping node types to lists of nodes.
 
         It may contain nodes that have been removed from the graph.
@@ -95,7 +94,7 @@ class JobShopGraph:
         return self._nodes_by_type
 
     @property
-    def nodes_by_machine(self) -> List[List[Node]]:
+    def nodes_by_machine(self) -> list[list[Node]]:
         """List of lists mapping machine ids to operation nodes.
 
         It may contain nodes that have been removed from the graph.
@@ -103,7 +102,7 @@ class JobShopGraph:
         return self._nodes_by_machine
 
     @property
-    def nodes_by_job(self) -> List[List[Node]]:
+    def nodes_by_job(self) -> list[list[Node]]:
         """List of lists mapping job ids to operation nodes.
 
         It may contain nodes that have been removed from the graph.
@@ -163,8 +162,8 @@ class JobShopGraph:
 
     def add_edge(
         self,
-        u_of_edge: Union[Node, int],
-        v_of_edge: Union[Node, int],
+        u_of_edge: Node | int,
+        v_of_edge: Node | int,
         **attr,
     ) -> None:
         """Adds an edge to the graph.
@@ -228,7 +227,7 @@ class JobShopGraph:
 
         self.graph.remove_nodes_from(isolated_nodes)
 
-    def is_removed(self, node: Union[int, Node]) -> bool:
+    def is_removed(self, node: int | Node) -> bool:
         """Returns whether the node is removed from the graph.
 
         Args:
@@ -241,7 +240,7 @@ class JobShopGraph:
             node = node.node_id
         return self.removed_nodes[node]
 
-    def non_removed_nodes(self) -> List[Node]:
+    def non_removed_nodes(self) -> list[Node]:
         """Returns the nodes that are not removed from the graph."""
         return [node for node in self._nodes if not self.is_removed(node)]
 

--- a/job_shop_lib/graphs/_node.py
+++ b/job_shop_lib/graphs/_node.py
@@ -1,7 +1,5 @@
 """Home of the `Node` class."""
 
-from typing import Optional
-
 from job_shop_lib import Operation
 from job_shop_lib.exceptions import (
     UninitializedAttributeError,
@@ -70,21 +68,17 @@ class Node:
     __slots__ = {
         "node_type": "The type of the node.",
         "_node_id": "Unique identifier for the node.",
-        "_operation": (
-            "The operation associated with the node."
-        ),
-        "_machine_id": (
-            "The machine ID associated with the node."
-        ),
+        "_operation": ("The operation associated with the node."),
+        "_machine_id": ("The machine ID associated with the node."),
         "_job_id": "The job ID associated with the node.",
     }
 
     def __init__(
         self,
         node_type: NodeType,
-        operation: Optional[Operation] = None,
-        machine_id: Optional[int] = None,
-        job_id: Optional[int] = None,
+        operation: Operation | None = None,
+        machine_id: int | None = None,
+        job_id: int | None = None,
     ):
         if node_type == NodeType.OPERATION and operation is None:
             raise ValidationError("Operation node must have an operation.")
@@ -96,7 +90,7 @@ class Node:
             raise ValidationError("Job node must have a job_id.")
 
         self.node_type: NodeType = node_type
-        self._node_id: Optional[int] = None
+        self._node_id: int | None = None
 
         self._operation = operation
         self._machine_id = machine_id

--- a/job_shop_lib/graphs/graph_updaters/_residual_graph_updater.py
+++ b/job_shop_lib/graphs/graph_updaters/_residual_graph_updater.py
@@ -1,7 +1,5 @@
 """Home of the `ResidualGraphUpdater` class."""
 
-from typing import Optional, List
-
 from job_shop_lib import ScheduledOperation
 from job_shop_lib.exceptions import UninitializedAttributeError
 from job_shop_lib.graphs import NodeType, JobShopGraph
@@ -56,7 +54,7 @@ class ResidualGraphUpdater(GraphUpdater):
         remove_completed_machine_nodes: bool = True,
         remove_completed_job_nodes: bool = True,
     ):
-        self._is_completed_observer: Optional[IsCompletedObserver] = None
+        self._is_completed_observer: IsCompletedObserver | None = None
         self.remove_completed_job_nodes = remove_completed_job_nodes
         self.remove_completed_machine_nodes = remove_completed_machine_nodes
         self._initialize_is_completed_observer_attribute(dispatcher)
@@ -82,7 +80,7 @@ class ResidualGraphUpdater(GraphUpdater):
                     return False
             return True
 
-        feature_types: List[FeatureType] = []
+        feature_types: list[FeatureType] = []
         if self.remove_completed_machine_nodes:
             feature_types.append(FeatureType.MACHINES)
         if self.remove_completed_job_nodes:

--- a/job_shop_lib/reinforcement_learning/__init__.py
+++ b/job_shop_lib/reinforcement_learning/__init__.py
@@ -48,7 +48,8 @@ from job_shop_lib.reinforcement_learning._multi_job_shop_graph_env import (
     MultiJobShopGraphEnv,
 )
 from ._resource_task_graph_observation import (
-    ResourceTaskGraphObservation, ResourceTaskGraphObservationDict
+    ResourceTaskGraphObservation,
+    ResourceTaskGraphObservationDict,
 )
 
 

--- a/job_shop_lib/reinforcement_learning/_multi_job_shop_graph_env.py
+++ b/job_shop_lib/reinforcement_learning/_multi_job_shop_graph_env.py
@@ -2,7 +2,7 @@
 
 from collections import defaultdict
 from collections.abc import Callable, Sequence
-from typing import Any, Tuple, Dict, List, Optional, Type
+from typing import Any
 from copy import deepcopy
 
 import gymnasium as gym
@@ -162,16 +162,16 @@ class MultiJobShopGraphEnv(gym.Env):
             [JobShopInstance], JobShopGraph
         ] = build_resource_task_graph,
         graph_updater_config: DispatcherObserverConfig[
-            Type[GraphUpdater]
+            type[GraphUpdater]
         ] = DispatcherObserverConfig(class_type=ResidualGraphUpdater),
         ready_operations_filter: Callable[
-            [Dispatcher, List[Operation]], List[Operation]
+            [Dispatcher, list[Operation]], list[Operation]
         ] = filter_dominated_operations,
         reward_function_config: DispatcherObserverConfig[
-            Type[RewardObserver]
+            type[RewardObserver]
         ] = DispatcherObserverConfig(class_type=MakespanReward),
-        render_mode: Optional[str] = None,
-        render_config: Optional[RenderConfig] = None,
+        render_mode: str | None = None,
+        render_config: RenderConfig | None = None,
         use_padding: bool = True,
     ) -> None:
         super().__init__()
@@ -226,7 +226,7 @@ class MultiJobShopGraphEnv(gym.Env):
     @property
     def ready_operations_filter(
         self,
-    ) -> Optional[Callable[[Dispatcher, List[Operation]], List[Operation]]]:
+    ) -> Callable[[Dispatcher, list[Operation]], list[Operation]] | None:
         """Returns the current ready operations filter."""
         return (
             self.single_job_shop_graph_env.dispatcher.ready_operations_filter
@@ -236,7 +236,7 @@ class MultiJobShopGraphEnv(gym.Env):
     def ready_operations_filter(
         self,
         ready_operations_filter: Callable[
-            [Dispatcher, List[Operation]], List[Operation]
+            [Dispatcher, list[Operation]], list[Operation]
         ],
     ) -> None:
         """Sets the ready operations filter."""
@@ -267,9 +267,9 @@ class MultiJobShopGraphEnv(gym.Env):
     def reset(
         self,
         *,
-        seed: Optional[int] = None,
-        options: Dict[str, Any] | None = None,
-    ) -> Tuple[ObservationDict, Dict[str, Any]]:
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[ObservationDict, dict[str, Any]]:
         """Resets the environment and returns the initial observation.
 
         Args:
@@ -303,8 +303,8 @@ class MultiJobShopGraphEnv(gym.Env):
         return obs, info
 
     def step(
-        self, action: Tuple[int, int]
-    ) -> Tuple[ObservationDict, float, bool, bool, Dict[str, Any]]:
+        self, action: tuple[int, int]
+    ) -> tuple[ObservationDict, float, bool, bool, dict[str, Any]]:
         """Takes a step in the environment.
 
         Args:
@@ -356,7 +356,7 @@ class MultiJobShopGraphEnv(gym.Env):
             input_shape: (num_machines, num_features)
             output_shape: (max_num_machines, num_features) (padded with -1)
         """
-        padding_value: Dict[str, float | bool] = defaultdict(lambda: -1)
+        padding_value: dict[str, float | bool] = defaultdict(lambda: -1)
         padding_value[ObservationSpaceKey.REMOVED_NODES.value] = True
         for key, value in observation.items():
             if not isinstance(value, np.ndarray):  # Make mypy happy
@@ -369,7 +369,7 @@ class MultiJobShopGraphEnv(gym.Env):
             )
         return observation
 
-    def _get_output_shape(self, key: str) -> Tuple[int, ...]:
+    def _get_output_shape(self, key: str) -> tuple[int, ...]:
         """Returns the output shape of the observation space key."""
         output_shape = self.observation_space[key].shape
         assert output_shape is not None  # Make mypy happy
@@ -378,12 +378,12 @@ class MultiJobShopGraphEnv(gym.Env):
     def render(self) -> None:
         self.single_job_shop_graph_env.render()
 
-    def get_available_actions_with_ids(self) -> List[Tuple[int, int, int]]:
+    def get_available_actions_with_ids(self) -> list[tuple[int, int, int]]:
         """Returns a list of available actions in the form of
         (operation_id, machine_id, job_id)."""
         return self.single_job_shop_graph_env.get_available_actions_with_ids()
 
-    def validate_action(self, action: Tuple[int, int]) -> None:
+    def validate_action(self, action: tuple[int, int]) -> None:
         """Validates the action.
 
         Args:

--- a/job_shop_lib/reinforcement_learning/_resource_task_graph_observation.py
+++ b/job_shop_lib/reinforcement_learning/_resource_task_graph_observation.py
@@ -245,7 +245,7 @@ class ResourceTaskGraphObservation(ObservationWrapper, Generic[EnvType]):
 
     @staticmethod
     def _get_start_from_zero_mappings(
-        original_indices_dict: dict[str, NDArray[np.int32]]
+        original_indices_dict: dict[str, NDArray[np.int32]],
     ) -> dict[str, dict[int, int]]:
         mappings = {}
         for key, indices in original_indices_dict.items():

--- a/job_shop_lib/reinforcement_learning/_reward_observers.py
+++ b/job_shop_lib/reinforcement_learning/_reward_observers.py
@@ -1,8 +1,6 @@
 """Rewards functions are defined as `DispatcherObervers` and are used to
 calculate the reward for a given state."""
 
-from typing import List
-
 from job_shop_lib.dispatching import DispatcherObserver, Dispatcher
 from job_shop_lib import ScheduledOperation
 
@@ -20,7 +18,7 @@ class RewardObserver(DispatcherObserver):
         self, dispatcher: Dispatcher, *, subscribe: bool = True
     ) -> None:
         super().__init__(dispatcher, subscribe=subscribe)
-        self.rewards: List[float] = []
+        self.rewards: list[float] = []
 
     @property
     def last_reward(self) -> float:

--- a/job_shop_lib/reinforcement_learning/_single_job_shop_graph_env.py
+++ b/job_shop_lib/reinforcement_learning/_single_job_shop_graph_env.py
@@ -2,7 +2,7 @@
 
 from copy import deepcopy
 from collections.abc import Callable, Sequence
-from typing import Any, Dict, Tuple, List, Optional, Type, Union
+from typing import Any
 
 import matplotlib.pyplot as plt
 import gymnasium as gym
@@ -140,24 +140,22 @@ class SingleJobShopGraphEnv(gym.Env):
         self,
         job_shop_graph: JobShopGraph,
         feature_observer_configs: Sequence[
-            Union[
-                str,
-                FeatureObserverType,
-                Type[FeatureObserver],
-                FeatureObserverConfig,
-            ],
+            str
+            | FeatureObserverType
+            | type[FeatureObserver]
+            | FeatureObserverConfig
         ],
         reward_function_config: DispatcherObserverConfig[
-            Type[RewardObserver]
+            type[RewardObserver]
         ] = DispatcherObserverConfig(class_type=MakespanReward),
         graph_updater_config: DispatcherObserverConfig[
-            Type[GraphUpdater]
+            type[GraphUpdater]
         ] = DispatcherObserverConfig(class_type=ResidualGraphUpdater),
-        ready_operations_filter: Optional[
-            Callable[[Dispatcher, List[Operation]], List[Operation]]
-        ] = filter_dominated_operations,
-        render_mode: Optional[str] = None,
-        render_config: Optional[RenderConfig] = None,
+        ready_operations_filter: (
+            Callable[[Dispatcher, list[Operation]], list[Operation]] | None
+        ) = filter_dominated_operations,
+        render_mode: str | None = None,
+        render_config: RenderConfig | None = None,
         use_padding: bool = True,
     ) -> None:
         super().__init__()
@@ -224,7 +222,7 @@ class SingleJobShopGraphEnv(gym.Env):
     def _get_observation_space(self) -> gym.spaces.Dict:
         """Returns the observation space dictionary."""
         num_edges = self.job_shop_graph.num_edges
-        dict_space: Dict[str, gym.Space] = {
+        dict_space: dict[str, gym.Space] = {
             ObservationSpaceKey.REMOVED_NODES.value: gym.spaces.MultiBinary(
                 len(self.job_shop_graph.nodes)
             ),
@@ -250,9 +248,9 @@ class SingleJobShopGraphEnv(gym.Env):
     def reset(
         self,
         *,
-        seed: Optional[int] = None,
-        options: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[ObservationDict, dict[str, Any]]:
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[ObservationDict, dict[str, Any]]:
         """Resets the environment.
 
         Args:
@@ -284,8 +282,8 @@ class SingleJobShopGraphEnv(gym.Env):
         }
 
     def step(
-        self, action: Tuple[int, int]
-    ) -> Tuple[ObservationDict, float, bool, bool, Dict[str, Any]]:
+        self, action: tuple[int, int]
+    ) -> tuple[ObservationDict, float, bool, bool, dict[str, Any]]:
         """Takes a step in the environment.
 
         Args:
@@ -319,7 +317,7 @@ class SingleJobShopGraphEnv(gym.Env):
         reward = self.reward_function.last_reward
         done = self.dispatcher.schedule.is_complete()
         truncated = False
-        info: Dict[str, Any] = {
+        info: dict[str, Any] = {
             "feature_names": self.composite_observer.column_names,
             "available_operations_with_ids": (
                 self.get_available_actions_with_ids()
@@ -374,7 +372,7 @@ class SingleJobShopGraphEnv(gym.Env):
         elif self.render_mode == "save_gif":
             self.gantt_chart_creator.create_gif()
 
-    def get_available_actions_with_ids(self) -> List[Tuple[int, int, int]]:
+    def get_available_actions_with_ids(self) -> list[tuple[int, int, int]]:
         """Returns a list of available actions in the form of
         (operation_id, machine_id, job_id)."""
         available_operations = self.dispatcher.available_operations()
@@ -388,7 +386,7 @@ class SingleJobShopGraphEnv(gym.Env):
                 )
         return available_operations_with_ids
 
-    def validate_action(self, action: Tuple[int, int]) -> None:
+    def validate_action(self, action: tuple[int, int]) -> None:
         """Validates that the action is legal in the current state.
 
         Args:
@@ -428,7 +426,7 @@ if __name__ == "__main__":
 
     instance = load_benchmark_instance("ft06")
     job_shop_graph_ = build_disjunctive_graph(instance)
-    feature_observer_configs_: List[DispatcherObserverConfig] = [
+    feature_observer_configs_: list[DispatcherObserverConfig] = [
         DispatcherObserverConfig(
             FeatureObserverType.IS_READY,
             kwargs={"feature_types": [FeatureType.JOBS]},

--- a/job_shop_lib/reinforcement_learning/_utils.py
+++ b/job_shop_lib/reinforcement_learning/_utils.py
@@ -1,6 +1,6 @@
 """Utility functions for reinforcement learning."""
 
-from typing import TypeVar, Any, Type
+from typing import TypeVar, Any
 
 import numpy as np
 from numpy.typing import NDArray
@@ -15,7 +15,7 @@ def add_padding(
     array: NDArray[Any],
     output_shape: tuple[int, ...],
     padding_value: float = -1,
-    dtype: Type[T] | None = None,
+    dtype: type[T] | None = None,
 ) -> NDArray[T]:
     """Adds padding to the array.
 

--- a/job_shop_lib/visualization/gantt/_gantt_chart_creator.py
+++ b/job_shop_lib/visualization/gantt/_gantt_chart_creator.py
@@ -1,6 +1,6 @@
 """Home of the `GanttChartCreator` class and its configuration types."""
 
-from typing import TypedDict, Optional
+from typing import TypedDict
 import matplotlib.pyplot as plt
 
 from job_shop_lib.dispatching import (
@@ -24,7 +24,7 @@ class PartialGanttChartPlotterConfig(TypedDict, total=False):
         - :func:`get_partial_gantt_chart_plotter`
     """
 
-    title: Optional[str]
+    title: str | None
     """The title of the Gantt chart."""
 
     cmap: str
@@ -43,7 +43,7 @@ class GifConfig(TypedDict, total=False):
         :func:`create_gantt_chart_gif`
     """
 
-    gif_path: Optional[str]
+    gif_path: str | None
     """The path to save the GIF. It must end with '.gif'."""
 
     fps: int
@@ -52,7 +52,7 @@ class GifConfig(TypedDict, total=False):
     remove_frames: bool
     """Whether to remove the frames after creating the GIF."""
 
-    frames_dir: Optional[str]
+    frames_dir: str | None
     """The directory to store the frames."""
 
     plot_current_time: bool
@@ -68,7 +68,7 @@ class VideoConfig(TypedDict, total=False):
         :func:`create_gantt_chart_video`
     """
 
-    video_path: Optional[str]
+    video_path: str | None
     """The path to save the video. It must end with a valid video extension
     (e.g., '.mp4')."""
 
@@ -78,7 +78,7 @@ class VideoConfig(TypedDict, total=False):
     remove_frames: bool
     """Whether to remove the frames after creating the video."""
 
-    frames_dir: Optional[str]
+    frames_dir: str | None
     """The directory to store the frames."""
 
     plot_current_time: bool
@@ -164,11 +164,11 @@ class GanttChartCreator:
     def __init__(
         self,
         dispatcher: Dispatcher,
-        partial_gantt_chart_plotter_config: Optional[
-            PartialGanttChartPlotterConfig
-        ] = None,
-        gif_config: Optional[GifConfig] = None,
-        video_config: Optional[VideoConfig] = None,
+        partial_gantt_chart_plotter_config: (
+            PartialGanttChartPlotterConfig | None
+        ) = None,
+        gif_config: GifConfig | None = None,
+        video_config: VideoConfig | None = None,
     ):
         if gif_config is None:
             gif_config = {}

--- a/job_shop_lib/visualization/gantt/_gantt_chart_video_and_gif_creation.py
+++ b/job_shop_lib/visualization/gantt/_gantt_chart_video_and_gif_creation.py
@@ -3,7 +3,7 @@
 import os
 import pathlib
 import shutil
-from typing import Sequence, Protocol, Optional, List, Any
+from typing import Sequence, Protocol, Any
 
 import imageio
 import matplotlib.pyplot as plt
@@ -43,9 +43,9 @@ class PartialGanttChartPlotter(Protocol):
     def __call__(
         self,
         schedule: Schedule,
-        makespan: Optional[int] = None,
-        available_operations: Optional[List[Operation]] = None,
-        current_time: Optional[int] = None,
+        makespan: int | None = None,
+        available_operations: list[Operation] | None = None,
+        current_time: int | None = None,
     ) -> Figure:
         """Plots a Gantt chart for an unfinished schedule.
 
@@ -65,7 +65,7 @@ class PartialGanttChartPlotter(Protocol):
 
 
 def get_partial_gantt_chart_plotter(
-    title: Optional[str] = None,
+    title: str | None = None,
     cmap: str = "viridis",
     show_available_operations: bool = False,
     **kwargs: Any,
@@ -95,9 +95,9 @@ def get_partial_gantt_chart_plotter(
 
     def plot_function(
         schedule: Schedule,
-        makespan: Optional[int] = None,
-        available_operations: Optional[List[Operation]] = None,
-        current_time: Optional[int] = None,
+        makespan: int | None = None,
+        available_operations: list[Operation] | None = None,
+        current_time: int | None = None,
     ) -> Figure:
         fig, ax = plot_gantt_chart(
             schedule, title=title, cmap_name=cmap, xlim=makespan, **kwargs
@@ -136,14 +136,14 @@ def get_partial_gantt_chart_plotter(
 # pylint: disable=too-many-arguments
 def create_gantt_chart_gif(
     instance: JobShopInstance,
-    gif_path: Optional[str] = None,
-    solver: Optional[DispatchingRuleSolver] = None,
-    plot_function: Optional[PartialGanttChartPlotter] = None,
+    gif_path: str | None = None,
+    solver: DispatchingRuleSolver | None = None,
+    plot_function: PartialGanttChartPlotter | None = None,
     fps: int = 1,
     remove_frames: bool = True,
-    frames_dir: Optional[str] = None,
+    frames_dir: str | None = None,
     plot_current_time: bool = True,
-    schedule_history: Optional[Sequence[ScheduledOperation]] = None,
+    schedule_history: Sequence[ScheduledOperation] | None = None,
 ) -> None:
     """Creates a GIF of the schedule being built.
 
@@ -205,14 +205,14 @@ def create_gantt_chart_gif(
 # pylint: disable=too-many-arguments
 def create_gantt_chart_video(
     instance: JobShopInstance,
-    video_path: Optional[str] = None,
-    solver: Optional[DispatchingRuleSolver] = None,
-    plot_function: Optional[PartialGanttChartPlotter] = None,
+    video_path: str | None = None,
+    solver: DispatchingRuleSolver | None = None,
+    plot_function: PartialGanttChartPlotter | None = None,
     fps: int = 1,
     remove_frames: bool = True,
-    frames_dir: Optional[str] = None,
+    frames_dir: str | None = None,
     plot_current_time: bool = True,
-    schedule_history: Optional[Sequence[ScheduledOperation]] = None,
+    schedule_history: Sequence[ScheduledOperation] | None = None,
 ) -> None:
     """Creates a video of the schedule being built.
 
@@ -271,10 +271,10 @@ def create_gantt_chart_video(
 def create_gantt_chart_frames(
     frames_dir: str,
     instance: JobShopInstance,
-    solver: Optional[DispatchingRuleSolver],
+    solver: DispatchingRuleSolver | None,
     plot_function: PartialGanttChartPlotter,
     plot_current_time: bool = True,
-    schedule_history: Optional[Sequence[ScheduledOperation]] = None,
+    schedule_history: Sequence[ScheduledOperation] | None = None,
 ) -> None:
     """Creates frames of the Gantt chart for the schedule being built.
 
@@ -414,7 +414,7 @@ def resize_image_to_macro_block(
     return image
 
 
-def _load_images(frames_dir: str) -> List:
+def _load_images(frames_dir: str) -> list:
     frames = [
         os.path.join(frames_dir, frame)
         for frame in sorted(os.listdir(frames_dir))

--- a/job_shop_lib/visualization/gantt/_plot_gantt_chart.py
+++ b/job_shop_lib/visualization/gantt/_plot_gantt_chart.py
@@ -1,7 +1,5 @@
 """Module for plotting static Gantt charts for job shop schedules."""
 
-from typing import Optional, List, Tuple, Dict
-
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 from matplotlib.colors import Normalize
@@ -15,16 +13,16 @@ _Y_POSITION_INCREMENT = 10
 
 def plot_gantt_chart(
     schedule: Schedule,
-    title: Optional[str] = None,
+    title: str | None = None,
     cmap_name: str = "viridis",
-    xlim: Optional[int] = None,
+    xlim: int | None = None,
     number_of_x_ticks: int = 15,
-    job_labels: Optional[List[str]] = None,
-    machine_labels: Optional[List[str]] = None,
+    job_labels: list[str] | None = None,
+    machine_labels: list[str] | None = None,
     legend_title: str = "",
     x_label: str = "Time units",
     y_label: str = "Machines",
-) -> Tuple[Figure, plt.Axes]:
+) -> tuple[Figure, plt.Axes]:
     """Plots a Gantt chart for the schedule.
 
     This function generates a Gantt chart that visualizes the schedule of jobs
@@ -90,10 +88,10 @@ def plot_gantt_chart(
 
 def _initialize_plot(
     schedule: Schedule,
-    title: Optional[str],
+    title: str | None,
     x_label: str = "Time units",
     y_label: str = "Machines",
-) -> Tuple[Figure, plt.Axes]:
+) -> tuple[Figure, plt.Axes]:
     """Initializes the plot."""
     fig, ax = plt.subplots()
     ax.set_xlabel(x_label)
@@ -110,8 +108,8 @@ def _plot_machine_schedules(
     schedule: Schedule,
     ax: plt.Axes,
     cmap_name: str,
-    job_labels: Optional[List[str]],
-) -> Dict[int, Patch]:
+    job_labels: list[str] | None,
+) -> dict[int, Patch]:
     """Plots the schedules for each machine."""
     max_job_id = schedule.instance.num_jobs - 1
     cmap = plt.get_cmap(cmap_name, max_job_id + 1)
@@ -137,7 +135,7 @@ def _plot_machine_schedules(
     return legend_handles
 
 
-def _get_job_label(job_labels: Optional[List[str]], job_id: int) -> str:
+def _get_job_label(job_labels: list[str] | None, job_id: int) -> str:
     """Returns the label for the job."""
     if job_labels is None:
         return f"Job {job_id}"
@@ -161,7 +159,7 @@ def _plot_scheduled_operation(
 
 
 def _configure_legend(
-    ax: plt.Axes, legend_handles: Dict[int, Patch], legend_title: str
+    ax: plt.Axes, legend_handles: dict[int, Patch], legend_title: str
 ):
     """Configures the legend for the plot."""
     sorted_legend_handles = [
@@ -178,7 +176,7 @@ def _configure_legend(
 def _configure_axes(
     schedule: Schedule,
     ax: plt.Axes,
-    xlim: Optional[int],
+    xlim: int | None,
     number_of_x_ticks: int,
     machine_labels: list[str] | None,
 ):

--- a/job_shop_lib/visualization/graphs/_plot_disjunctive_graph.py
+++ b/job_shop_lib/visualization/graphs/_plot_disjunctive_graph.py
@@ -1,7 +1,7 @@
 """Module for visualizing the disjunctive graph of a job shop instance."""
 
 import functools
-from typing import Any, Optional, Tuple, Dict, Union
+from typing import Any
 from collections.abc import Callable, Sequence, Iterable
 import warnings
 import copy
@@ -23,7 +23,7 @@ from job_shop_lib.graphs import (
 from job_shop_lib.exceptions import ValidationError
 
 
-Layout = Callable[[nx.Graph], Dict[str, Tuple[float, float]]]
+Layout = Callable[[nx.Graph], dict[str, tuple[float, float]]]
 
 
 def duration_labeler(node: Node) -> str:
@@ -56,10 +56,10 @@ def duration_labeler(node: Node) -> str:
 # pylint: disable=too-many-arguments, too-many-locals, too-many-statements
 # pylint: disable=too-many-branches, line-too-long
 def plot_disjunctive_graph(
-    job_shop: Union[JobShopGraph, JobShopInstance],
+    job_shop: JobShopGraph | JobShopInstance,
     *,
-    title: Optional[str] = None,
-    figsize: Tuple[float, float] = (6, 4),
+    title: str | None = None,
+    figsize: tuple[float, float] = (6, 4),
     node_size: int = 1600,
     edge_width: int = 2,
     font_size: int = 10,
@@ -67,27 +67,25 @@ def plot_disjunctive_graph(
     alpha: float = 0.95,
     operation_node_labeler: Callable[[Node], str] = duration_labeler,
     node_font_color: str = "white",
-    machine_colors: Optional[
-        Dict[int, Tuple[float, float, float, float]]
-    ] = None,
+    machine_colors: dict[int, tuple[float, float, float, float]] | None = None,
     color_map: str = "Dark2_r",
     disjunctive_edge_color: str = "red",
     conjunctive_edge_color: str = "black",
-    layout: Optional[Layout] = None,
-    draw_disjunctive_edges: Union[bool, str] = True,
-    conjunctive_edges_additional_params: Optional[Dict[str, Any]] = None,
-    disjunctive_edges_additional_params: Optional[Dict[str, Any]] = None,
+    layout: Layout | None = None,
+    draw_disjunctive_edges: bool | str = True,
+    conjunctive_edges_additional_params: dict[str, Any] | None = None,
+    disjunctive_edges_additional_params: dict[str, Any] | None = None,
     conjunctive_patch_label: str = "Conjunctive edges",
     disjunctive_patch_label: str = "Disjunctive edges",
     legend_text: str = "$p_{ij}=$duration of $O_{ij}$",
     show_machine_colors_in_legend: bool = True,
-    machine_labels: Optional[Sequence[str]] = None,
+    machine_labels: Sequence[str] | None = None,
     legend_location: str = "upper left",
-    legend_bbox_to_anchor: Tuple[float, float] = (1.01, 1),
+    legend_bbox_to_anchor: tuple[float, float] = (1.01, 1),
     start_node_label: str = "$S$",
     end_node_label: str = "$T$",
     font_family: str = "sans-serif",
-) -> Tuple[plt.Figure, plt.Axes]:
+) -> tuple[plt.Figure, plt.Axes]:
     r"""Plots the disjunctive graph of the given job shop instance or graph.
 
     Args:
@@ -240,7 +238,7 @@ def plot_disjunctive_graph(
     # Draw nodes
     # ----------
     operation_nodes = job_shop_graph.nodes_by_type[NodeType.OPERATION]
-    cmap_func: Optional[matplotlib.colors.Colormap] = None
+    cmap_func: matplotlib.colors.Colormap | None = None
     if machine_colors is None:
         machine_colors = {}
         cmap_func = matplotlib.colormaps.get_cmap(color_map)
@@ -289,7 +287,7 @@ def plot_disjunctive_graph(
         for u, v, d in job_shop_graph.graph.edges(data=True)
         if d["type"] == EdgeType.CONJUNCTIVE
     ]
-    disjunctive_edges: Iterable[Tuple[int, int]] = [
+    disjunctive_edges: Iterable[tuple[int, int]] = [
         (u, v)
         for u, v, d in job_shop_graph.graph.edges(data=True)
         if d["type"] == EdgeType.DISJUNCTIVE

--- a/job_shop_lib/visualization/graphs/_plot_resource_task_graph.py
+++ b/job_shop_lib/visualization/graphs/_plot_resource_task_graph.py
@@ -10,7 +10,7 @@ all operation nodes from the same job are connected by non-directed edges too.
 
 from collections.abc import Callable
 from copy import deepcopy
-from typing import Optional, Any, Tuple, Dict, Union, List
+from typing import Any
 
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
@@ -22,24 +22,22 @@ from job_shop_lib.graphs import NodeType, JobShopGraph, Node
 def plot_resource_task_graph(
     job_shop_graph: JobShopGraph,
     *,
-    title: Optional[str] = None,
-    figsize: Tuple[int, int] = (10, 10),
-    layout: Optional[Dict[Node, Tuple[float, float]]] = None,
+    title: str | None = None,
+    figsize: tuple[int, int] = (10, 10),
+    layout: dict[Node, tuple[float, float]] | None = None,
     node_size: int = 1200,
     node_font_color: str = "k",
     font_size: int = 10,
     alpha: float = 0.95,
     add_legend: bool = False,
-    node_shapes: Optional[Dict[str, str]] = None,
-    node_color_map: Optional[
-        Callable[[Node], Tuple[float, float, float, float]]
-    ] = None,
-    default_node_color: Union[
-        str, Tuple[float, float, float, float]
-    ] = "lightblue",
+    node_shapes: dict[str, str] | None = None,
+    node_color_map: (
+        Callable[[Node], tuple[float, float, float, float]] | None
+    ) = None,
+    default_node_color: str | tuple[float, float, float, float] = "lightblue",
     machine_color_map_name: str = "tab10",
     legend_text: str = "$p_{ij}$ = duration of $O_{ij}$",
-    edge_additional_params: Optional[Dict[str, Any]] = None,
+    edge_additional_params: dict[str, Any] | None = None,
     draw_only_one_edge: bool = False,
 ) -> plt.Figure:
     """Returns a plot of the hetereogeneous graph of the instance.
@@ -203,17 +201,17 @@ def _get_node_label(node: Node) -> str:
 
 
 def _color_to_rgba(
-    color: Union[str, Tuple[float, float, float, float]]
-) -> Tuple[float, float, float, float]:
+    color: str | tuple[float, float, float, float],
+) -> tuple[float, float, float, float]:
     if isinstance(color, str):
         return mcolors.to_rgba(color)
     return color
 
 
 def color_nodes_by_machine(
-    machine_colors: Dict[int, Tuple[float, float, float, float]],
-    default_color: Union[str, Tuple[float, float, float, float]],
-) -> Callable[[Node], Tuple[float, float, float, float]]:
+    machine_colors: dict[int, tuple[float, float, float, float]],
+    default_color: str | tuple[float, float, float, float],
+) -> Callable[[Node], tuple[float, float, float, float]]:
     """Returns a function that assigns a color to a node based on its type.
 
     The function returns a color based on the node type. If the node is an
@@ -234,7 +232,7 @@ def color_nodes_by_machine(
         values of the color to use in the plot.
     """
 
-    def _get_node_color(node: Node) -> Tuple[float, float, float, float]:
+    def _get_node_color(node: Node) -> tuple[float, float, float, float]:
         if node.node_type == NodeType.OPERATION:
             return machine_colors[node.operation.machine_id]
         if node.node_type == NodeType.MACHINE:
@@ -252,7 +250,7 @@ def three_columns_layout(
     rightmost_position: float = 0.9,
     topmost_position: float = 1.0,
     bottommost_position: float = 0.0,
-) -> Dict[Node, Tuple[float, float]]:
+) -> dict[Node, tuple[float, float]]:
     """Generates coordinates for a three-column grid layout.
 
     1. Left column: Machine nodes (M1, M2, etc.)
@@ -321,7 +319,7 @@ def three_columns_layout(
     total_positions = len(operation_nodes) + len(global_nodes) * 2
     y_spacing = (topmost_position - bottommost_position) / total_positions
 
-    layout: Dict[Node, Tuple[float, float]] = {}
+    layout: dict[Node, tuple[float, float]] = {}
 
     machines_spacing_multiplier = len(operation_nodes) // len(machine_nodes)
     layout.update(
@@ -364,7 +362,7 @@ def three_columns_layout(
 
 def _get_x_positions(
     leftmost_position: float, rightmost_position: float
-) -> Dict[str, float]:
+) -> dict[str, float]:
     center_position = (
         leftmost_position + (rightmost_position - leftmost_position) / 2
     )
@@ -376,12 +374,12 @@ def _get_x_positions(
 
 
 def _assign_positions_from_top(
-    nodes: List[Node],
+    nodes: list[Node],
     x: float,
     top: float,
     y_spacing: float,
-) -> Dict[Node, Tuple[float, float]]:
-    layout: Dict[Node, Tuple[float, float]] = {}
+) -> dict[Node, tuple[float, float]]:
+    layout: dict[Node, tuple[float, float]] = {}
     for i, node in enumerate(nodes):
         y = top - (i + 1) * y_spacing
         layout[node] = (x, y)

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -115,9 +115,7 @@ def test_from_job_sequences_invalid(
         [1, 0, 2],
     ]
     with pytest.raises(ValidationError):
-        Schedule.from_job_sequences(
-            example_job_shop_instance, job_sequences
-        )
+        Schedule.from_job_sequences(example_job_shop_instance, job_sequences)
 
 
 def test_to_dict(example_job_shop_instance: JobShopInstance):


### PR DESCRIPTION
Removes the need to import `typing.List`, `typing.Dict`, etc. and instead uses `list[...]`, `dict[...]` etc. 

Discussed in #26